### PR TITLE
Fix: Passwords containing "=" are no longer truncated.

### DIFF
--- a/config_parser.c
+++ b/config_parser.c
@@ -171,7 +171,7 @@ static int load_parameter(config_t config, const char *line)
             return 0;
         }
     } else {
-        value = strtok(NULL, CFG_DELIMITER_CHR);
+        value = strtok(NULL, "");
         switch(param_type)
         {
         case HTTP_PORT:


### PR DESCRIPTION
Specifying a delimiter for `strtok(NULL, ...)` not only takes the next token, but also replaces following delimiter with '\0'. 

The old behavior caused any password containing `=` to be truncated where the equal sign was.

New behavior ensures that the remaining token is not modified.
